### PR TITLE
Do not prepend `chr` to BED

### DIFF
--- a/kmer_repeat_counter.py
+++ b/kmer_repeat_counter.py
@@ -47,9 +47,6 @@ class MSILocusLoader:
                 for line in filein.readlines():
                     if line[0] != '@':
                         locus = MSILocus(line)
-                        if locus.chromosome[0:3] != 'chr':
-                            # Force-prepend the chr prefix
-                            locus.chromosome = 'chr{0}'.format(locus.chromosome)
 
                         # Correct any off-by-one errors that may occur because of 
                         # unstandardized open- and closed-endedness of bed file coordinates.


### PR DESCRIPTION
Fix for https://github.com/OSU-SRLab/MANTIS/issues/17.  This is a really bad idea for reasons mentioned in #17.  My genome reference does not have `chr` prefixes, and besides, this may not be on human or other genomes with `chr` prefixes!